### PR TITLE
Fix the CPU idle problem

### DIFF
--- a/generator/api_generator.py
+++ b/generator/api_generator.py
@@ -32,9 +32,3 @@ class ApiGenerator:
         for api in self.apis:
             api_model = APIModel(api)
             yield api_model
-
-        
-
-
-
-    

--- a/generator/method_generator.py
+++ b/generator/method_generator.py
@@ -185,6 +185,4 @@ class MethodCombGenerator:
         # Apk completed analyzing
         outter_loop.clear()
         outter_loop.close()
-
-        self.set_progress_status(1)
         return

--- a/generator/method_generator.py
+++ b/generator/method_generator.py
@@ -81,7 +81,7 @@ class MethodCombGenerator:
 
         return True
 
-    def first_stage_rule_generate(self, apis_pool):
+    def first_stage_rule_generate(self, first_apis_pool, second_apis_pool):
         """
         Extract all api usage in apk current apk then generate method combination.
 
@@ -96,16 +96,16 @@ class MethodCombGenerator:
         if not self.check_progress():
             return
 
-        api_generator = ApiGenerator(self.apk.apis)
-        origin_apis = list(api_generator.generate())
+        api_generator = ApiGenerator(second_apis_pool)
+        inner_api_pool = list(api_generator.generate())
 
         # Setup progress bar
-        origin_apis_num = len(origin_apis)
+        second_api_pool_num = len(inner_api_pool)
         outter_desc = f"Core No.{self.pbar}"
-        outter_loop = tqdm(apis_pool, desc=outter_desc,
+        outter_loop = tqdm(first_apis_pool, desc=outter_desc,
                            position=self.pbar, leave=False)
 
-        for api1 in apis_pool:
+        for api1 in first_apis_pool:
             outter_loop.update(1)
 
             # Tag the method
@@ -122,8 +122,8 @@ class MethodCombGenerator:
 
             matched_list = []
             id_list = []
-            for num, api2 in enumerate(origin_apis, start=1):
-                inner_desc = f"{num}/{origin_apis_num}"
+            for num, api2 in enumerate(inner_api_pool, start=1):
+                inner_desc = f"{num}/{second_api_pool_num}"
                 outter_loop.set_postfix(inner_loop=inner_desc, refresh=True)
 
                 api = api2

--- a/generator/method_generator.py
+++ b/generator/method_generator.py
@@ -134,8 +134,8 @@ class MethodCombGenerator:
 
                 _comb = {
                     "crime": "",
-                    "x1_permission": [],
-                    "x2n3n4_comb": [
+                    "permission": [],
+                    "api": [
                         {
                             "class": api1.class_name,
                             "method": api1.method_name,
@@ -147,7 +147,7 @@ class MethodCombGenerator:
                             "descriptor": api2.descriptor
                         }
                     ],
-                    "yscore": 1
+                    "score": 1
                 }
                 comb = GenRuleObject(_comb)
 

--- a/generator/object/genrule_obj.py
+++ b/generator/object/genrule_obj.py
@@ -5,22 +5,22 @@ from quark.Objects.quarkrule import QuarkRule
 
 class GenRuleObject(QuarkRule):
     __slots__ = ["check_item", "_json_obj", "_crime",
-                 "_x1_permission", "_x2n3n4_comb", "_yscore", "rule_filename"]
+                 "_permission", "_api", "_score", "rule_filename"]
 
     def __init__(self, json_obj):
         """
         According to customized JSON rules, calculate the weighted score and assessing the stages of the crime.
 
-        :param json_filename:
+        :param json_obj:
         """
         # the state of five stages
         self.check_item = [False, False, False, False, False]
 
         self._json_obj = json_obj
         self._crime = self._json_obj["crime"]
-        self._x1_permission = self._json_obj["x1_permission"]
-        self._x2n3n4_comb = self._json_obj["x2n3n4_comb"]
-        self._yscore = self._json_obj["yscore"]
+        self._permission = self._json_obj["permission"]
+        self._api = self._json_obj["api"]
+        self._score = self._json_obj["score"]
         self.rule_filename = None
 
     def __repr__(self):
@@ -36,31 +36,31 @@ class GenRuleObject(QuarkRule):
         return self._crime
 
     @property
-    def x1_permission(self):
+    def permission(self):
         """
         Permission requested by the apk to practice the crime.
 
         :return: a list of given permissions
         """
-        return self._x1_permission
+        return self._permission
 
     @property
-    def x2n3n4_comb(self):
+    def api(self):
         """
         Key native APIs that do the action and target in order.
 
         :return: a list recording the APIs class_name and method_name in order
         """
-        return self._x2n3n4_comb
+        return self._api
 
     @property
-    def yscore(self):
+    def score(self):
         """
         The value used to calculate the weighted score
 
         :return: integer
         """
-        return self._yscore
+        return self._score
 
     def get_score(self, confidence):
         """
@@ -74,4 +74,4 @@ class GenRuleObject(QuarkRule):
         """
         if confidence == 0:
             return 0
-        return (2 ** (confidence - 1) * self._yscore) / 2 ** 4
+        return (2 ** (confidence - 1) * self._score) / 2 ** 4

--- a/model/android_sample_model.py
+++ b/model/android_sample_model.py
@@ -1,4 +1,4 @@
-from utils import tools
+from utils.tools import sha256sum
 from quark.Objects.quark import Quark
 from db.database import DataBase
 
@@ -13,7 +13,7 @@ class AndroidSampleModel:
 
         self.db = DataBase()
         self.apk = apk
-        self.apk_hash = tools.sha256sum(apk)
+        self.apk_hash = sha256sum(apk)
         self.parsable = True
 
         self.db.create_sample_data(self.obj)
@@ -73,14 +73,14 @@ class AndroidSampleModel:
         if not self.parsable:
             return None
 
-        result = list()
+        result = set()
         for cls in self.apk_analysis.apkinfo.analysis.get_external_classes():
             for meth_analysis in cls.get_methods():
                 if meth_analysis.is_android_api():
-                    result.append(meth_analysis)
+                    result.add(meth_analysis)
 
-        return result
-
+        return list(result)
+            
     @property
     def status(self):
         if not self.parsable:

--- a/test/generator/object/test_genrule_obj.py
+++ b/test/generator/object/test_genrule_obj.py
@@ -1,0 +1,72 @@
+
+import os
+
+import pytest
+from generator.object.genrule_obj import GenRuleObject
+
+
+@pytest.fixture(scope="function")
+def incomplete_rule():
+    incomplete_rule = {}
+    
+    return incomplete_rule
+
+@pytest.fixture(scope="function")
+def complete_rule():
+    complete_rule = {
+        "crime": "Send Location via SMS",
+        "permission": [
+            "android.permission.SEND_SMS",
+            "android.permission.ACCESS_COARSE_LOCATION",
+            "android.permission.ACCESS_FINE_LOCATION"
+        ],
+        "api": [
+            {
+                "class": "Landroid/telephony/TelephonyManager",
+                "method": "getCellLocation",
+                "descriptor": "()Landroid/telephony/CellLocation;"
+            },
+            {
+                "class": "Landroid/telephony/SmsManager",
+                "method": "sendTextMessage",
+                "descriptor": "(Ljava/lang/String; Ljava/lang/String; Ljava/lang/String; Landroid/app/PendingIntent; Landroid/app/PendingIntent;)V"
+            }
+        ],
+        "score": 4,
+    }
+    return complete_rule
+
+
+class TestGenRuleObject:
+    
+    def test_init_with_incomplete_rule(self, incomplete_rule):
+        with pytest.raises(KeyError):
+            _ = GenRuleObject(incomplete_rule)
+
+    def test_init_with_complete_rule(self, complete_rule):
+        rule = GenRuleObject(complete_rule)
+
+        assert all(rule.check_item) is False
+        assert rule.crime == "Send Location via SMS"
+        assert rule.permission == [
+            "android.permission.SEND_SMS",
+            "android.permission.ACCESS_COARSE_LOCATION",
+            "android.permission.ACCESS_FINE_LOCATION",
+        ]
+        assert rule.api == [
+            {
+                "class": "Landroid/telephony/TelephonyManager",
+                "method": "getCellLocation",
+                "descriptor": "()Landroid/telephony/CellLocation;",
+            },
+            {
+                "class": "Landroid/telephony/SmsManager",
+                "method": "sendTextMessage",
+                "descriptor": (
+                    "(Ljava/lang/String; Ljava/lang/String;"
+                    " Ljava/lang/String; Landroid/app/PendingIntent;"
+                    " Landroid/app/PendingIntent;)V"
+                ),
+            },
+        ]
+        assert rule.score == 4

--- a/test/generator/test_api_generator.py
+++ b/test/generator/test_api_generator.py
@@ -1,0 +1,15 @@
+
+import pytest
+from generator.api_generator import ApiGenerator
+from model.android_sample_model import AndroidSampleModel
+
+@pytest.fixture()
+def apk_analysis(scope="function"):
+    return AndroidSampleModel("test/sample/test_sample.apk")
+    
+
+class TestApiGenerator:
+    
+    def test_statistic(self, apk_analysis):
+        apis = ApiGenerator(apk_analysis.apis)
+        print(apis.statistic())

--- a/test/model/test_android_sample_model.py
+++ b/test/model/test_android_sample_model.py
@@ -1,0 +1,19 @@
+import pytest
+from pprint import pprint
+from model.android_sample_model import AndroidSampleModel
+
+@pytest.fixture(scope="function")
+def invalid_file(tmp_path):
+    invalid_file = tmp_path / "invalid_file.txt"
+    invalid_file.write_text("Not apk file")
+
+    yield invalid_file
+
+@pytest.fixture(scope="function")
+def valid_file():
+    return "test/sample/test_sample.apk"
+
+class TestAndroidSampleModel:
+    
+    def test_apis(self, valid_file):
+        pass

--- a/utils/tools.py
+++ b/utils/tools.py
@@ -56,4 +56,26 @@ def distribute(seq, sort):
     """
     new_seq = numpy.array_split(seq, sort)
     return new_seq
+
+def api_filter(apk, percentile_rank):
+    statistic_result = {}
+    api_pool = apk.apis
+    for api in api_pool:
+        number_from = len(apk.apk_analysis.apkinfo.upperfunc(api))
+        statistic_result[api] = number_from
+
+    sorted_result = {k: v for k, v in sorted(statistic_result.items(), key=lambda item: item[1])}
     
+    threshold = len(api_pool) * percentile_rank
+    api_above = []
+    api_under = []
+    p_count = {"first": [], "second": []}
+    for i, (api, number) in enumerate(sorted_result.items()):
+        if i < threshold:
+            api_above.append(api)
+            p_count["first"].append(number)
+            continue
+        p_count["second"].append(number)
+        api_under.append(api)
+        
+    return api_above, api_under, p_count


### PR DESCRIPTION
#### Description

This PR fixed the CPU idle problem when using multiprocess.

The multiprocess evenly distribute APIs to each process for analysis. However, some processes will idle when it is faster than others, which is not an effective use of resources.

I implemented a feature that continuously checks the CPU status and reallocates the rest of the APIs to other CPUs when one is idle.

**Note:**
This PR must merge after [PR #2](https://github.com/quark-engine/quark-rule-generate/pull/2)